### PR TITLE
Consolidate entry points around a single __main__.py

### DIFF
--- a/hydrus/__main__.py
+++ b/hydrus/__main__.py
@@ -1,0 +1,65 @@
+import argparse
+import pyspark
+
+from hydrus.features import Loader, TfIdfTransformer
+
+
+# TODO: perhaps there is a better way to arrange a SparkContext,
+# especially if we are submitting through `spark-submit`.
+conf = pyspark.SparkConf().setAppName('hydrus')
+ctx = pyspark.SparkContext(conf=conf)
+
+
+def preprocess(args):
+    '''Inspect the output of the data loader and TF-IDF transformer.
+    '''
+    data, labels = Loader(ctx).read(args.data_path, args.label_path)
+    data = TfIdfTransformer(ctx).fit(data).transform(data)
+
+    print('Data sample: ', data.take(1)[0])
+    if labels is not None:
+        print('Label sample:', labels.take(1)[0])
+
+    if args.all:
+        print('All data:')
+        def print_rdd(x):
+            ((doc, word), count, *features) = x
+            print(f'{doc:8}', end='\t')
+            print(f'{word:15}', end='\t')
+            print(f'{count:3}', end='\t')
+            for f in features:
+                print(f'{f:.3f}', end='\t')
+            print()
+        data.foreach(lambda x: print_rdd(x))
+
+
+def hello(args):
+    '''Prints 'hello world' or another string given by `args.string`.
+
+    This is purely an example for how to add new subcommands.
+    '''
+    if not args.string: args.string = 'hello world'
+    print(args.string)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Execute hydrus commands')
+    subcommands = parser.add_subparsers()
+
+    # hydrus hello [-s STRING]
+    cmd = subcommands.add_parser('hello', description='Prints hello world.')
+    cmd.add_argument('-s', '--string', help='print this string instead.')
+    cmd.set_defaults(func=hello)
+
+    # hydrus preprocess [-a] data_path label_path
+    cmd = subcommands.add_parser('preprocess', description='Inspect the data loader and TF-IDF transformer')
+    cmd.add_argument('data_path', help='path to the data file')
+    cmd.add_argument('label_path', help='path to the label file')
+    cmd.add_argument('-a', '--all', action='store_true', help='print all data points')
+    cmd.set_defaults(func=preprocess)
+
+    args = parser.parse_args()
+    if hasattr(args, 'func'):
+        args.func(args)
+    else:
+        parser.print_help()

--- a/hydrus/features.py
+++ b/hydrus/features.py
@@ -207,34 +207,3 @@ class TfIdfTransformer:
 
         data = data.map(tf_idf, preservesPartitioning=True)
         return data
-
-
-if __name__ == '__main__':
-    import argparse
-    parser = argparse.ArgumentParser(description='Inspect the data loader and TF-IDF transformer')
-    parser.add_argument('data_path', help='path to the data file')
-    parser.add_argument('label_path', help='path to the label file')
-    parser.add_argument('-a', '--all', action='store_true', help='print all data points')
-    args = parser.parse_args()
-
-    conf = pyspark.SparkConf().setAppName('hydrus-p1-dataloader-test')
-    ctx = pyspark.SparkContext(conf=conf)
-
-    data, labels = Loader(ctx).read(args.data_path, args.label_path)
-    data = TfIdfTransformer(ctx).fit(data).transform(data)
-
-    print('Data sample: ', data.take(1)[0])
-    if labels is not None:
-        print('Label sample:', labels.take(1)[0])
-
-    if args.all:
-        print('All data:')
-        def print_rdd(x):
-            ((doc, word), count, *features) = x
-            print(f'{doc:8}', end='\t')
-            print(f'{word:15}', end='\t')
-            print(f'{count:3}', end='\t')
-            for f in features:
-                print(f'{f:.3f}', end='\t')
-            print()
-        data.foreach(lambda x: print_rdd(x))


### PR DESCRIPTION
I recognized from recent events that we need a place to consolidate all of the different entry points that we might have, so I created a global `__main__` for the project.

Commands can be executed like this:
```
$ python -m hydrus <SUBCOMMAND> <ARGS..>
```

So far I have two commands.
- `preprocess`: This command inspects the output of the preprocess stage. This previously existed in the `hydrus.features` module. 
- `hello`: This command prints "hello world". The purpose of this command is to demonstrate how to add new commands.

So how do you add new commands? It's easy.  First you define your subcommand to the parser like this:

```python
cmd = subcommands.add_parser('hello', description='Prints hello world.')
cmd.add_argument('-s', '--string', help='print this string instead.')
cmd.set_defaults(func=hello)
```

The final line there specifies the function to run. In this case `cmd.set_defaults(func=hello)` means we want the `hello` function to handle this command. Then all you have to do is define the function:

```python
def hello(args):
    '''Prints 'hello world' or another string given by `args.string`.

    This is purely an example for how to add new subcommands.
    '''
    if not args.string: args.string = 'hello world'
    print(args.string)
```

It accepts one argument, `args`, which contains the arguments parsed from the command line.

Note that this conflicts with #5 which renames the `hydrus.features` module to `hydrus.preprocess`.