### PR TITLE
Use zipWithIndex to preserve relative ordering

### DIFF
--- a/hydrus/features.py
+++ b/hydrus/features.py
@@ -109,13 +109,13 @@ class Loader:
         # Create an RDD of all documents keyed by document ID.
         # We cast the doc_id to str to be easier to work with labels.
         data = self.ctx.textFile(data_path)           # (full_text)
-        data = data.zipWithUniqueId()                 # (full_text, doc_id)
+        data = data.zipWithIndex()                    # (full_text, doc_id)
         data = data.map(lambda x: (str(x[1]), x[0]))  # (doc_id, full_text)
 
         # Create an RDD of labels keyed by document ID.
         if label_path is not None:
             labels = self.ctx.textFile(label_path)                  # (label_list)
-            labels = labels.zipWithUniqueId()                       # (label_list, doc_id)
+            labels = labels.zipWithIndex()                          # (label_list, doc_id)
             labels = labels.map(lambda x: (str(x[1]), x[0]))        # (doc_id, label_list)
             labels = labels.flatMapValues(lambda s: s.split(','))   # (doc_id, label)
             labels = labels.filter(lambda x: x[1].endswith('CAT'))  # (doc_id, label)


### PR DESCRIPTION
`zipWithUniqueId` does not generate keys that preserve relative ordering. This PR switches to `zipWithIndex`.

Closes #12