### PR TITLE
Clean TfIdfTransformer and RddTensor, remove the *splat operator

### DIFF
--- a/hydrus/__main__.py
+++ b/hydrus/__main__.py
@@ -13,23 +13,23 @@ ctx = pyspark.SparkContext(conf=conf)
 def preprocess(args):
     '''Inspect the output of the data loader and TF-IDF transformer.
     '''
-    data, labels = Loader(ctx).read(args.data_path, args.label_path)
-    data = TfIdfTransformer(ctx).fit(data).transform(data)
+    counts, labels = Loader(ctx).read(args.data_path, args.label_path)
+    tfidfs = TfIdfTransformer(ctx).fit(counts).transform(counts)
 
-    print('Data sample: ', data.take(1)[0])
+    print('Data sample: ', counts.take(1)[0])
     if labels is not None:
         print('Label sample:', labels.take(1)[0])
 
     if args.all:
         print('All data:')
         def print_rdd(x):
-            ((doc, word), count, *features) = x
-            print(f'{doc:8}', end='\t')
-            print(f'{word:15}', end='\t')
-            print(f'{count:3}', end='\t')
-            for f in features:
-                print(f'{f:.3f}', end='\t')
+            ((doc, word), (count, tfidf)) = x
+            print('{doc:8}'.format(locals()), end='\t')
+            print('{word:15}'.format(locals()), end='\t')
+            print('{count:3}'.format(locals()), end='\t')
+            print('{tfidf:3}'.format(locals()), end='\t')
             print()
+        data = sounts.join(labels)
         data.foreach(lambda x: print_rdd(x))
 
 

--- a/hydrus/logistic.py
+++ b/hydrus/logistic.py
@@ -15,10 +15,9 @@ class LogisticRegression:
         '''
         self.ctx = ctx
         self.weights = None
-        self.feature = 0
         self.ids = None
 
-    def fit(self, x, y, lr=0.01, batch_size=-1, max_iter=1, feature=0, warm_start=False):
+    def fit(self, x, y, lr=0.01, batch_size=-1, max_iter=1, warm_start=False):
         '''Train the model on some dataset and labels.
 
         Args:
@@ -36,17 +35,13 @@ class LogisticRegression:
                 greater than the size of the training set.
             max_iter: Positive int
                 The maximum number of epochs to train.
-            feature: Positive int
-                The index of the feature to learn from in the case that `x`
-                has more than one feature.
             warm_start: bool
                 If True, the weights are not (re)initialized.
         '''
         self.ids = y.keys().distinct().collect()
         self.ids = frozenset(self.ids)
-        self.feature = feature
 
-        x = RddTensor(x, 2, feature=feature)
+        x = RddTensor(x, 2)
         y = RddTensor.from_catigorical(y)
 
         if not warm_start:
@@ -98,7 +93,7 @@ class LogisticRegression:
         Returns: RDD (id, label)
             An RDD mapping IDs to predicted labels.
         '''
-        x = RddTensor(x, 2, feature=self.feature)
+        x = RddTensor(x, 2)
         h = (x @ self.weights).argmax().rdd   # ((doc_id,), label)
         h = h.map(lambda x: (x[0][0], x[1]))  # (doc_id, label)
         return h


### PR DESCRIPTION
Lowers the compatibility requirements below Python 3.5.

This appears to be a breaking change for #8 in terms of how to access TF-IDF values, so head up.

It also makes the `RDD.values()` method more useful.

See #17 