### PR TITLE
Add some convenience 

### DIFF
--- a/hydrus/__init__.py
+++ b/hydrus/__init__.py
@@ -1,0 +1,13 @@
+from . import logistic
+from . import math
+from . import postprocess
+from . import preprocess
+
+
+def interactive(*args, **kwargs):
+    '''Creates a SparkContext for interactive use.
+    '''
+    import pyspark
+    conf = pyspark.SparkConf(*args, **kwargs)
+    ctx = pyspark.SparkContext(conf=conf)
+    return ctx


### PR DESCRIPTION
This reexports all submodules the top level module, so we only need a single `import hydrus` to get everything.

It also adds a `hydrus.interactive()` function to spin up a SparkContext for when you're not in pyspark.